### PR TITLE
Fix actions and update to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,14 +1,16 @@
 name: main
 on:
-  - pull_request
-  - push
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 jobs:
   tests:
     name: Tests on ${{matrix.node}}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node}}
       - run: npm install
@@ -16,7 +18,6 @@ jobs:
     strategy:
       matrix:
         node:
-          - lts/gallium
           - lts/hydrogen
           - lts/iron
           - node
@@ -24,9 +25,9 @@ jobs:
     name: Lint and format check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "lts/iron"
       - run: npm install
-      - run: npm run lint
+      - run: npm run check

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ const InfoBox = (properties, children) =>
   h(
     ".infobox",
     h(".infobox-title", properties.title || "Info"),
-    h(".infobox-body", children)
+    h(".infobox-body", children),
   );
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -9,46 +9,48 @@ example), and it allows you to provide a custom component function that renders
 the contents of that element.
 
 It's like the idea of React components except that it works on static HTML trees
-in [rehype][] and it operates on plain HAST nodes. You can use tools from the HAST
-ecosystem, like [hastscript][], to create and manipulate the content that your
-components render.
+in [rehype][] and it operates on plain HAST nodes. You can use tools from the
+HAST ecosystem, like [hastscript][], to create and manipulate the content that
+your components render.
 
 A component's rendering function receives the custom element's attributes and
 children, and it produces a new HTML tree as its output.
 
 ## Installation
 
-
-
 ```sh
 npm install rehype-components
 ```
 
 ```js
-import rehypeComponents from 'rehype-components';
+import rehypeComponents from "rehype-components";
 ```
 
 ## Example
 
-Attach the plugin. In this example we're initializing a [unified][] processor and we attach the plugin into its pipeline. Typically you would have some plugins placed before this one, to ingest or pre-process the document, and some other plugins after it to post-process and output the result (for example by rendering the HTML to a string at the end).
+Attach the plugin. In this example we're initializing a [unified][] processor
+and we attach the plugin into its pipeline. Typically you would have some
+plugins placed before this one, to ingest or pre-process the document, and some
+other plugins after it to post-process and output the result (for example by
+rendering the HTML to a string at the end).
 
 ```js
 unified()
   // ...
   .use(rehypeComponents, {
-    // The `components` field is an object that maps the custom element names to their component rendering 
-    // functions. 
+    // The `components` field is an object that maps the custom element names to their component rendering
+    // functions.
     components: {
       "documentation-page": DocumentationPage,
       "info-box": InfoBox,
       "copyright-notice": CopyrightNotice,
     },
   });
-// ... 
+// ...
 ```
 
-Here's some sample input HTML content, with custom elements `documentation-page`, `info-box`, and
-`copyright-notice`:
+Here's some sample input HTML content, with custom elements
+`documentation-page`, `info-box`, and `copyright-notice`:
 
 ```html
 <documentation-page title="Welcome">

--- a/test.js
+++ b/test.js
@@ -53,7 +53,7 @@ test("example from readme", async () => {
     h(
       ".infobox",
       h(".infobox-title", properties.title || "Info"),
-      h(".infobox-body", children)
+      h(".infobox-body", children),
     );
 
   const output = await processDocument(
@@ -65,7 +65,7 @@ test("example from readme", async () => {
         "copyright-notice": CopyrightNotice,
       },
     },
-    true
+    true,
   );
   assert.deepEqual(String(output), expected);
 });
@@ -120,11 +120,11 @@ test("component returns invalid content", async () => {
     err => {
       assert.strictEqual(
         err.message.includes("expected to return ElementContent"),
-        true
+        true,
       );
       return true;
     },
-    "Did not throw with expected error message"
+    "Did not throw with expected error message",
   );
 });
 


### PR DESCRIPTION
Fix actions to

- make them not run in double in PR commits
- fix to run check (prettier + eslint) instead of just lint
- drop oldest node version

Also:
- update auto-formatting of readme